### PR TITLE
Cogito landing page (workspaces/homepage)

### DIFF
--- a/workspaces/faucet/Readme.md
+++ b/workspaces/faucet/Readme.md
@@ -1,5 +1,7 @@
-Faucet
-======
+---
+path: /faucet
+title: Faucet
+---
 
 This is a very simple faucet Express app. It supports the following REST call:
 

--- a/workspaces/homepage/gatsby-config.js
+++ b/workspaces/homepage/gatsby-config.js
@@ -10,6 +10,12 @@ module.exports = {
       }
     },
     {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        path: `${__dirname}/../faucet`
+      }
+    },
+    {
       resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [

--- a/workspaces/homepage/src/components/Editing.js
+++ b/workspaces/homepage/src/components/Editing.js
@@ -1,12 +1,18 @@
 import React from 'react'
 
-const editUrl =
-  'https://github.com/Charterhouse/react-frontend-developer/' +
-  'blob/master/workspaces/homepage/src/pages'
+const editUrl = 'https://github.com/philips-software/cogito/blob/master'
 
 export const EditFile = ({ fileAbsolutePath }) => {
-  const fileName = fileAbsolutePath.split('/').pop()
-  return <div>
-    <a href={`${editUrl}/${fileName}`}>Edit this page</a>
-  </div>
+  console.log('fileAbsolutePath=', fileAbsolutePath)
+  const match = fileAbsolutePath.match(/workspaces.*$/)
+  if (match) {
+    const fileRelativePath = match[0]
+    console.log('fileRelativePath=', fileRelativePath)
+    return (
+      <div>
+        <a href={`${editUrl}/${fileRelativePath}`}>Edit this page</a>
+      </div>
+    )
+  }
+  return null
 }


### PR DESCRIPTION
On this branch I started to redesign the homepage. The plan is to start exposing the workspace-specific READMEs via Confluenza-based homepage. I started with faucet to check if it works. I also plan to redesign the homepage so that it follows our black-and-white styling but in the meantime, if you like, you can continue working on connecting READMEs from other workspaces and adding the actual content.