### PR TITLE
Remove the need to include the Babel polyfill when you're using Cogito

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,10 @@ function setupPresets (babelEnv) {
   if (babelEnv === 'es' || babelEnv === 'umd') {
     presetEnv = [
       '@babel/preset-env',
-      { modules: false }
+      {
+        modules: false,
+        exclude: ['transform-regenerator']
+      }
     ]
   }
 

--- a/workspaces/demo-app/package.json
+++ b/workspaces/demo-app/package.json
@@ -14,7 +14,6 @@
     "@react-frontend-developer/css-grid-helper": "^1.0.6",
     "@react-frontend-developer/react-layout-helpers": "^1.0.6",
     "@react-frontend-developer/react-redux-render-prop": "^1.0.6",
-    "babel-polyfill": "^6.26.0",
     "glamor": "^2.20.40",
     "glamorous": "^4.13.1",
     "jsrsasign": "^8.0.12",

--- a/workspaces/demo-app/src/index.js
+++ b/workspaces/demo-app/src/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,7 +3297,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.20.0, babel-polyfill@^6.26.0:
+babel-polyfill@^6.20.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:


### PR DESCRIPTION
Benefit: easier to use Cogito javascript packages.
Downside: slightly larger packages.