### PR TITLE
Adds supports for special CONFLUENZA.md file in the components

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "workspaces/*"
   ],
-  "version": "0.2.14",
+  "version": "0.2.15",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/workspaces/cogito-attestations/README.md
+++ b/workspaces/cogito-attestations/README.md
@@ -1,0 +1,6 @@
+# @cogitojs/cogito-attestations
+
+This library allows retrieval of attestations that are stored in a Cogito app.
+
+We are currently working on the documentation - please stay tuned and visit 
+[cogito.mobi](https://cogito.mobi) for more information.

--- a/workspaces/cogito-attestations/Readme.md
+++ b/workspaces/cogito-attestations/Readme.md
@@ -1,8 +1,0 @@
-Cogito Attestations
-===================
-
-This library allows retrieval of attestations that are stored in a Cogito app.
-
-[Documentation][3]
-
-[3]: https://cogito.mobi

--- a/workspaces/cogito-attestations/package.json
+++ b/workspaces/cogito-attestations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-attestations",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Allows retrieval of attestations through the Cogito app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",

--- a/workspaces/cogito-encryption/README.md
+++ b/workspaces/cogito-encryption/README.md
@@ -1,0 +1,6 @@
+# @cogitojs/cogito-encryption
+
+This library allows encryption and decryption using keys store in a Cogito app.
+
+We are currently working on the documentation - please stay tuned and visit 
+[cogito.mobi](https://cogito.mobi) for more information.

--- a/workspaces/cogito-encryption/Readme.md
+++ b/workspaces/cogito-encryption/Readme.md
@@ -1,8 +1,0 @@
-Cogito Encryption
-=================
-
-This library allows encryption and decryption using keys store in a Cogito app.
-
-[Documentation][3]
-
-[3]: https://cogito.mobi

--- a/workspaces/cogito-encryption/package.json
+++ b/workspaces/cogito-encryption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-encryption",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Supports encryption and decryption through the Cogito app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cogitojs/crypto": "0.2.x",
+    "@cogitojs/crypto": "^0.2.15",
     "@react-frontend-developer/buffers": "^1.0.10",
     "@trust/keyto": "^0.3.2",
     "base64url": "^2.0.0",

--- a/workspaces/cogito-identity/CONFLUENZA.md
+++ b/workspaces/cogito-identity/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/cogito-identity
+title: Cogito Identity
+tag: component
+content: README.md
+---

--- a/workspaces/cogito-identity/README.md
+++ b/workspaces/cogito-identity/README.md
@@ -32,4 +32,4 @@ console.log(info.ethereumAddress, info.username)
 Currently, `ethereumAddress` and `username` are the only identity attributes supported
 by `CogitoIdentity`.
 
-[telepath]: /components/telepath-js
+[telepath]: https://cogito.mobi/components/telepath-js

--- a/workspaces/cogito-identity/README.md
+++ b/workspaces/cogito-identity/README.md
@@ -1,8 +1,4 @@
----
-path: /components/cogito-identity
-title: Cogito Identity
-tag: component
----
+# @cogitojs/cogito-identity
 
 `@cogitojs/cogito-identity` allows retrieving identity information over [telepath] (e.g. from a Cogito app).
 

--- a/workspaces/cogito-identity/package.json
+++ b/workspaces/cogito-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-identity",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Supports getting identity info from the Cogito app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",

--- a/workspaces/cogito-react-ui/README.md
+++ b/workspaces/cogito-react-ui/README.md
@@ -1,0 +1,4 @@
+# @cogitojs/cogito-react-ui
+
+`@cogitojs/cogito-react-ui` provides ui components that make building React client apps
+a bit easier.

--- a/workspaces/cogito-react-ui/package.json
+++ b/workspaces/cogito-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-react-ui",
-  "version": "0.2.12",
+  "version": "0.2.15",
   "description": "Cogito React library",
   "homepage": "https://cogito.mobi",
   "license": "MIT",

--- a/workspaces/cogito-react/CONFLUENZA.md
+++ b/workspaces/cogito-react/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/cogito-react
+title: Cogito React
+tag: component
+content: README.md
+---

--- a/workspaces/cogito-react/README.md
+++ b/workspaces/cogito-react/README.md
@@ -158,8 +158,8 @@ contracts.dataRequest  // raw
 contracts.dataResponse // raw
 ```
 
-[@cogitojs/cogito]: /components/cogito
-[Cogito]: /components/cogito
-[CogitoProvider]: /components/cogito-web3
-[Telepath]: /components/telepath-js
+[@cogitojs/cogito]: https://cogito.mobi/components/cogito
+[Cogito]: https://cogito.mobi/components/cogito
+[CogitoProvider]: https://cogito.mobi/components/cogito-web3
+[Telepath]: https://cogito.mobi/components/telepath-js
 [Working with Contracts]: #working-with-contracts

--- a/workspaces/cogito-react/README.md
+++ b/workspaces/cogito-react/README.md
@@ -1,8 +1,4 @@
----
-path: /components/cogito-react
-title: Cogito React
-tag: component
----
+# @cogitojs/cogito-react
 
 `@cogitojs/cogito-react` is a React version of [@cogitojs/cogito].
 

--- a/workspaces/cogito-react/package.json
+++ b/workspaces/cogito-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-react",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Cogito React library",
   "homepage": "https://cogito.mobi",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "rollup-plugin-uglify": "^3.0.0"
   },
   "dependencies": {
-    "@cogitojs/cogito": "^0.2.14"
+    "@cogitojs/cogito": "^0.2.15"
   },
   "peerDependencies": {
     "libsodium-wrappers": "^0.7.2",

--- a/workspaces/cogito-web3/CONFLUENZA.md
+++ b/workspaces/cogito-web3/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/cogito-web3
+title: Cogito Web3
+tag: component
+content: README.md
+---

--- a/workspaces/cogito-web3/README.md
+++ b/workspaces/cogito-web3/README.md
@@ -1,8 +1,4 @@
----
-path: /components/cogito-web3
-title: Cogito Web3
-tag: component
----
+# @cogitojs/cogito-web3
 
 `@cogitojs/cogito-web3` provides a means to intercept some of the standard
 [Web3] requests and redirect them to the Cogito mobile app using the [telepath] channel.

--- a/workspaces/cogito-web3/package.json
+++ b/workspaces/cogito-web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito-web3",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "An Ethereum web3 provider that signs transactions with the Cogito app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",

--- a/workspaces/cogito/CONFLUENZA.md
+++ b/workspaces/cogito/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/cogito
+title: Cogito
+tag: component
+content: README.md
+---

--- a/workspaces/cogito/README.md
+++ b/workspaces/cogito/README.md
@@ -120,7 +120,7 @@ const {web3, channel, contracts} = await cogito.update({
 This will reuse an existing Telepath channel.
 
 [Web3]: https://github.com/ethereum/web3.js
-[cogito-web3]: /components/cogito-web3
-[telepath]: /components/telepath-js
-[telepath-js]: /components/telepath-js
+[cogito-web3]: https://cogito.mobi/components/cogito-web3
+[telepath]: https://cogito.mobi/components/telepath-js
+[telepath-js]: https://cogito.mobi/components/telepath-js
 [Ethereum contracts]: http://www.ethdocs.org/en/latest/contracts-and-transactions/index.html

--- a/workspaces/cogito/README.md
+++ b/workspaces/cogito/README.md
@@ -1,8 +1,4 @@
----
-path: /components/cogito
-title: Cogito
-tag: component
----
+# @cogitojs/cogito
 
 `@cogitojs/cogito` is a high level convenience components that provides a more
 declarative way of working with [cogito-web3], [telepath], and [Ethereum contracts].

--- a/workspaces/cogito/package.json
+++ b/workspaces/cogito/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/cogito",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Cogito library for web app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "rollup-plugin-uglify": "^3.0.0"
   },
   "dependencies": {
-    "@cogitojs/cogito-web3": "^0.2.14",
-    "@cogitojs/telepath-js": "^0.2.14"
+    "@cogitojs/cogito-web3": "^0.2.15",
+    "@cogitojs/telepath-js": "^0.2.15"
   },
   "peerDependencies": {
     "libsodium-wrappers": "^0.7.2",

--- a/workspaces/crypto/CONFLUENZA.md
+++ b/workspaces/crypto/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/crypto
+title: Crypto
+tag: component
+content: README.md
+---

--- a/workspaces/crypto/README.md
+++ b/workspaces/crypto/README.md
@@ -1,8 +1,4 @@
----
-path: /components/crypto
-title: Crypto
-tag: component
----
+# @cogitojs/crypto
 
 The `@cogitojs/crypto` package provides cryptographic utilities used by other cogito packages.
 

--- a/workspaces/crypto/package.json
+++ b/workspaces/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/crypto",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "description": "Crypto utilities for cogito",
   "homepage": "https://cogito.mobi",
   "license": "MIT",

--- a/workspaces/faucet/CONFLUENZA.md
+++ b/workspaces/faucet/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/faucet
+title: Faucet
+tag: component
+content: README.md
+---

--- a/workspaces/faucet/README.md
+++ b/workspaces/faucet/README.md
@@ -1,8 +1,4 @@
----
-path: /components/faucet
-title: Faucet
-tag: component
----
+# faucet
 
 This is a very simple faucet Express app. It supports the following REST call:
 

--- a/workspaces/faucet/package.json
+++ b/workspaces/faucet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/faucet",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "description": "Simple faucet with REST API",
   "homepage": "https://cogito.mobi",
   "license": "MIT",
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "ganache-cli": "^6.1.0",
-    "supertest": "^3.3.0",
-    "mock-fs": "^4.7.0"
+    "mock-fs": "^4.7.0",
+    "supertest": "^3.3.0"
   },
   "dependencies": {
     "@babel/cli": "^7.0.0",

--- a/workspaces/homepage/gatsby-config.js
+++ b/workspaces/homepage/gatsby-config.js
@@ -30,7 +30,8 @@ module.exports = {
     {
       resolve: 'gatsby-source-filesystem',
       options: {
-        path: `${__dirname}/../telepath-ios/README.md`
+        path: `${__dirname}/../telepath-ios`,
+        ignore: [`**/Pods/**/*`]
       }
     },
     {

--- a/workspaces/homepage/gatsby-node.js
+++ b/workspaces/homepage/gatsby-node.js
@@ -25,10 +25,12 @@ exports.createPages = async ({ actions, graphql }) => {
   }
 
   queryResult.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    createPage({
-      path: node.frontmatter.path,
-      component: markdownTemplate,
-      context: {}
-    })
+    if (node.frontmatter.path) {
+      createPage({
+        path: node.frontmatter.path,
+        component: markdownTemplate,
+        context: {}
+      })
+    }
   })
 }

--- a/workspaces/homepage/src/components/navigation/NavigationItem.js
+++ b/workspaces/homepage/src/components/navigation/NavigationItem.js
@@ -17,13 +17,15 @@ class NavigationItem extends React.Component {
   )
 
   render () {
-    const { node: { headings, frontmatter: { title, path } }, onChange, location } = this.props
+    const { node: { headings, frontmatter: { title, path, content } }, onChange, location } = this.props
+
+    const actualHeadings = content ? content.childMarkdownRemark.headings : headings
 
     return (
       <li key={path}>
         <MidLevelNavigationItem location={location} path={path} title={title} onChange={onChange}>
-          { headings.length > 0 && <List>
-            { headings.map((heading, index) => this.renderNavigationHeading(heading, index, path)) }
+          { actualHeadings.length > 0 && <List>
+            { actualHeadings.map((heading, index) => this.renderNavigationHeading(heading, index, path)) }
           </List> }
         </MidLevelNavigationItem>
       </li>

--- a/workspaces/homepage/src/layouts/documentation/DocumentationLayout.js
+++ b/workspaces/homepage/src/layouts/documentation/DocumentationLayout.js
@@ -46,6 +46,14 @@ const DocumentationLayout = ({ children, location }) => (
                 title
                 path
                 tag
+                content {
+                  childMarkdownRemark {
+                    html
+                    headings(depth: h2) {
+                      value
+                    }
+                  }
+                }
               }
               headings(depth: h2) {
                 value

--- a/workspaces/homepage/src/pages/developer-documentation/introduction.md
+++ b/workspaces/homepage/src/pages/developer-documentation/introduction.md
@@ -15,4 +15,4 @@ you're more than welcome to. We even wrote
 to help you get started on your first contribution. If you need any help, feel
 free to reach out to us on [Slack](https://philips-software-slackin.now.sh/).
 
-[cogito.mobi]: /
+[cogito.mobi]: https://cogito.mobi

--- a/workspaces/homepage/src/templates/markdownTemplate.js
+++ b/workspaces/homepage/src/templates/markdownTemplate.js
@@ -8,7 +8,7 @@ const Template = ({ data: { doc }, location }) => {
   return (
     <div>
       <Helmet title={title} />
-      <EditFile fileAbsolutePath={fileAbsolutePath} />
+      <EditFile fileAbsolutePath={content ? content.childMarkdownRemark.fileAbsolutePath : fileAbsolutePath} />
       <h1>{title}</h1>
       <div dangerouslySetInnerHTML={{ __html: content ? content.childMarkdownRemark.html.split('\n').slice(1).join('\n') : html }} />
     </div>
@@ -25,6 +25,7 @@ export const pageQuery = graphql`
         content {
           childMarkdownRemark {
             html
+            fileAbsolutePath
           }
         }
       }

--- a/workspaces/homepage/src/templates/markdownTemplate.js
+++ b/workspaces/homepage/src/templates/markdownTemplate.js
@@ -4,13 +4,13 @@ import { EditFile } from 'src/components/Editing'
 import { graphql } from 'gatsby'
 
 const Template = ({ data: { doc }, location }) => {
-  const { html, fileAbsolutePath, frontmatter: { title } } = doc
+  const { html, fileAbsolutePath, frontmatter: { title, content } } = doc
   return (
     <div>
       <Helmet title={title} />
       <EditFile fileAbsolutePath={fileAbsolutePath} />
       <h1>{title}</h1>
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <div dangerouslySetInnerHTML={{ __html: content ? content.childMarkdownRemark.html.split('\n').slice(1).join('\n') : html }} />
     </div>
   )
 }
@@ -22,6 +22,11 @@ export const pageQuery = graphql`
       fileAbsolutePath
       frontmatter {
         title
+        content {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }

--- a/workspaces/telepath-ios/CONFLUENZA.md
+++ b/workspaces/telepath-ios/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/telepath-ios
+title: Telepath (iOS)
+tag: component
+content: README.md
+---

--- a/workspaces/telepath-ios/README.md
+++ b/workspaces/telepath-ios/README.md
@@ -1,6 +1,6 @@
 # telepath-ios
 
-> For a general introduction to telepath, please check [telepath-js](/components/telepath-js).
+> For a general introduction to telepath, please check [telepath-js](https://cogito.mobi/components/telepath-js).
 
 ## Usage
 
@@ -55,4 +55,4 @@ channel.receive { message: String?, error: Error? in
 
 The received `message` will be `nil` when no message is available.
 
-[queuing]: /components/telepath-queuing-service
+[queuing]: https://cogito.mobi/components/telepath-queuing-service

--- a/workspaces/telepath-ios/README.md
+++ b/workspaces/telepath-ios/README.md
@@ -1,9 +1,4 @@
----
-path: /components/telepath-ios
-title: Telepath (iOS)
-tag: component
----
-
+# telepath-ios
 
 > For a general introduction to telepath, please check [telepath-js](/components/telepath-js).
 

--- a/workspaces/telepath-js/CONFLUENZA.md
+++ b/workspaces/telepath-js/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/telepath-js
+title: Telepath (JavaScript)
+tag: component
+content: README.md
+---

--- a/workspaces/telepath-js/README.md
+++ b/workspaces/telepath-js/README.md
@@ -134,4 +134,4 @@ Currently uses independent encryption of messages. A recipient can therefore not
 
 Telepath often comes hand in hand with [Cogito Web3].
 
-[Cogito Web3]: /components/cogito-web3
+[Cogito Web3]: https://cogito.mobi/components/cogito-web3

--- a/workspaces/telepath-js/README.md
+++ b/workspaces/telepath-js/README.md
@@ -1,8 +1,4 @@
----
-path: /components/telepath-js
-title: Telepath (JavaScript)
-tag: component
----
+# @cogitojs/telepath-js
 
 Provides a secure channel for communication between a web app running in a browser and an app running on a mobile device.
 

--- a/workspaces/telepath-js/package.json
+++ b/workspaces/telepath-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogitojs/telepath-js",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Secure communication channel between mobile app and web app",
   "homepage": "https://cogito.mobi",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "rollup-plugin-uglify": "^3.0.0"
   },
   "dependencies": {
-    "@cogitojs/crypto": "0.2.x",
+    "@cogitojs/crypto": "^0.2.15",
     "base64url": "^2.0.0",
     "cross-fetch": "^2.1.1"
   },

--- a/workspaces/telepath-queuing-service/CONFLUENZA.md
+++ b/workspaces/telepath-queuing-service/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /components/telepath-queuing-service
+title: Telepath Queuing Service
+tag: component
+content: README.md
+---

--- a/workspaces/telepath-queuing-service/README.md
+++ b/workspaces/telepath-queuing-service/README.md
@@ -1,8 +1,4 @@
----
-path: /components/telepath-queuing-service
-title: Telepath Queuing Service
-tag: component
----
+# telepath-queuing-service
 
 Simple Queueing Service for use with Telepath. Allows two Telepath clients to
 communicate when they are behind a distinct NAT.


### PR DESCRIPTION
Every workspace has a README.md file. This file is rendered by github, but some of them are also rendered on npmjs website. Last by not least they are also rendered on our cogito.mobi homepage in the `components` documentation section.

cogito.mobi uses confluenza to render the documentation page out of various markdown sources. While doing this, it looks at the files so called `frontmatter` containing important metadata like `title`, `path` and `tag`. These metadata do not have any meaning outside of the confluenza environment and therefore should not be kept in the actual README file. This is especially important for sites like npmjs that do not render (1) frontmatter correctly, (2) would bring confusion to the reader.

For this reason, if README of the given workspace should be included in the documentation without adding `frontmatter` to it, we create a file called `CONFLUENZA.md` containing only frontmatter.

For example, here is the contents of the `CONFLUENZA.md` file from the `faucet` workspace:

```
---
path: /components/faucet
title: Faucet
tag: component
content: README.md
---
```

The `content` field indicates that the intended content of this `CONFLUENZA.md` file is to be found in the `README.md` file, from which we can now remove the `frontmatter`.

Confluenza only renders markdown file that contain the `frontmatter`. The [gatsby-transformer-remark](https://www.npmjs.com/package/gatsby-transformer-remark) plugin recognises the `content` field in the `frontmatter` and if it can resolve the file indicated by its value, it will process it as a regular markdown file and the result of this processing will be captured in the `content` field. Below I show the example of the remark node corresponding to the `CONFLUENZA.md` file of the `faucet` workspace:

```
{
    "node": {
        "id": "4d399582-8c83-57c9-b00f-9727c0953f07",
        "fileAbsolutePath": "/Users/mczenko/Documents/Projects/open-source/cogito/workspaces/faucet/CONFLUENZA.md",
        "html": "",
        "frontmatter": {
            "title": "Faucet",
            "path": "/components/faucet",
            "content": {
                "childMarkdownRemark": {
                    "fileAbsolutePath": "/Users/mczenko/Documents/Projects/open-source/cogito/workspaces/faucet/README.md",
                    "html": "<h1>....",
                    "headings": [
                        { "value": "Installation" },
                        { "value": "Parameters" },
                        { "value": "Example" },
                        { "value": "Using the faucet" }
                    ]
                }
            }
        }
    }
}
```

Now, for each rendered content, Confluenza checks if `frontmatter` of the corresponding node contains the `content` field. If it does, Confluenza uses the `childMarkdownRemark` to render the page, otherwise it will use the original content. This way, the markdown files with `frontmatter` without the `content` field will be rendered  without any change. Finally, as mentioned above, if `frontmatter` is not present in the markdown file, Confluenza will ignore that file.

This pull request adds the `CONFLUENZA.md` files to all currently rendered workspaces.

It also updates the links to fix issue #23.