### PR TITLE
Allow faucet to run on a port different from 3001

### DIFF
--- a/workspaces/faucet/README.md
+++ b/workspaces/faucet/README.md
@@ -27,6 +27,8 @@ The `cogito-faucet` command takes the following arguments:
    * `-p` or `--provider` followed by the provider URL. This specifies the full
      URL of the node in your blockchain network (including `http` or `https` and
      port number if needed). Defaults to `http://localhost:8545`.
+   * `--port` followed by a port number. The port that the faucet listens on.
+     Defaults to `3001`
 
 The private key that corresponds with the account is specified as an environment
 variable:

--- a/workspaces/faucet/bin/cogito-faucet.js
+++ b/workspaces/faucet/bin/cogito-faucet.js
@@ -16,6 +16,7 @@ program
     'URL of the Ethereum provider',
     'http://localhost:8545'
   )
+  .option('--port <number>', 'Port number to listen on', '3001', parseInt)
   .parse(process.argv)
 
 var faucetServer = new FaucetServer({
@@ -25,6 +26,6 @@ var faucetServer = new FaucetServer({
   privateKey: process.env.COGITO_FAUCET_PRIVATE_KEY
 })
 
-faucetServer.server.listen(3001, function () {
-  console.log('Running on port 3001')
+faucetServer.server.listen(program.port, function () {
+  console.log(`Running on port ${program.port}`)
 })

--- a/workspaces/faucet/source/faucet-server.test.js
+++ b/workspaces/faucet/source/faucet-server.test.js
@@ -53,30 +53,14 @@ describe('Server', () => {
     it('returns response status 500', async () => {
       const address = '0x0000000000000000000000000000000000000001'
       const error = new Error('some error 2')
-
-      // THIS DOES NOT WORK FOR ERROR HANDLING - DO NOT KNOW WHY!
-      // donate.mockReturnValueOnce(Promise.reject(error))
-      // and
-      // donate.mockRejectedValueOnce(error)
-      donate.mockImplementationOnce(() => {
-        return Promise.reject(error)
-      })
-
+      donate.mockRejectedValueOnce(error)
       await request(faucetServer.server).post(`/donate/${address}`).expect(500)
     })
 
     it('returns correct error message when error does not have response.statusText field', async () => {
       const address = '0x0000000000000000000000000000000000000001'
       const error = new Error('some error 2')
-
-      // THIS DOES NOT WORK FOR ERROR HANDLING - DO NOT KNOW WHY!
-      // donate.mockReturnValueOnce(Promise.reject(error))
-      // and
-      // donate.mockRejectedValueOnce(error)
-      donate.mockImplementationOnce(() => {
-        return Promise.reject(error)
-      })
-
+      donate.mockRejectedValueOnce(error)
       await request(faucetServer.server)
         .post(`/donate/${address}`)
         .expect('some error 2 - please check logs')
@@ -95,15 +79,7 @@ describe('Server', () => {
         }
       }
       const error = new CustomError('error status text', 'error message')
-
-      // THIS DOES NOT WORK FOR ERROR HANDLING - DO NOT KNOW WHY!
-      // donate.mockReturnValueOnce(Promise.reject(error))
-      // and
-      // donate.mockRejectedValueOnce(error)
-      donate.mockImplementationOnce(() => {
-        return Promise.reject(error)
-      })
-
+      donate.mockRejectedValueOnce(error)
       await request(faucetServer.server)
         .post(`/donate/${address}`)
         .expect('error message - error status text')

--- a/workspaces/faucet/source/faucet-server.test.js
+++ b/workspaces/faucet/source/faucet-server.test.js
@@ -20,7 +20,7 @@ describe('Server', () => {
 
   describe('happy flow', () => {
     beforeEach(() => {
-      donate.mockResolvedValueOnce({status: true})
+      donate.mockResolvedValueOnce({ status: true })
       console.log = jest.fn()
     })
 
@@ -30,16 +30,14 @@ describe('Server', () => {
 
     it('supports donate URL', async () => {
       const address = '0x0000000000000000000000000000000000000001'
-      await request(faucetServer.server)
-        .post(`/donate/${address}`)
-        .expect(200)
+      await request(faucetServer.server).post(`/donate/${address}`).expect(200)
     })
 
     it('returns correct message on success', async () => {
       const address = '0x0000000000000000000000000000000000000001'
       await request(faucetServer.server)
         .post(`/donate/${address}`)
-        .expect(200, JSON.stringify({status: true}))
+        .expect(200, JSON.stringify({ status: true }))
     })
   })
 
@@ -64,9 +62,7 @@ describe('Server', () => {
         return Promise.reject(error)
       })
 
-      await request(faucetServer.server)
-        .post(`/donate/${address}`)
-        .expect(500)
+      await request(faucetServer.server).post(`/donate/${address}`).expect(500)
     })
 
     it('returns correct error message when error does not have response.statusText field', async () => {
@@ -127,7 +123,7 @@ describe('Server', () => {
           console.log('queue=', faucetServer.queue.length)
           if (this.fulfilStatus) {
             expect(faucetServer.queue.length).toBe(this.maxExpectedQueueSize)
-            resolve({status: true})
+            resolve({ status: true })
           } else if (this.counter === 0) {
             reject(new Error('timeout'))
           } else {
@@ -160,13 +156,9 @@ describe('Server', () => {
 
     it('immediately schedules a donator call when no previous call is present', async () => {
       expect(faucetServer.queue.length).toBe(0)
-
-      donate.mockResolvedValueOnce({status: true})
-
+      donate.mockResolvedValueOnce({ status: true })
       const address = '0x0000000000000000000000000000000000000001'
-      await request(faucetServer.server)
-        .post(`/donate/${address}`)
-        .expect(200)
+      await request(faucetServer.server).post(`/donate/${address}`).expect(200)
     })
 
     it('puts a request on a waiting queue and removes the item from the queue after it is served', done => {


### PR DESCRIPTION
The port number is now a command line parameter (defaulting to 3001).