### PR TITLE
Corrects the edit-this-page link (after aligning with confluenza - monorepos need a special change)

### DIFF
--- a/workspaces/homepage/src/components/Editing.js
+++ b/workspaces/homepage/src/components/Editing.js
@@ -22,7 +22,7 @@ const Wrapper = glamorous.div({
 
 class EditFile extends React.Component {
   renderEditThisPageLink = (fileAbsolutePath, linkText) => {
-    const match = fileAbsolutePath.match(/.*\/(src.*)$/) || fileAbsolutePath.match(/.*\/(.*)$/)
+    const match = fileAbsolutePath.match(/.*\/(workspaces.*)$/) || fileAbsolutePath.match(/.*\/(.*)$/)
     if (match) {
       const fileRelativePath = match[1]
       const { editBaseUrl } = this.props


### PR DESCRIPTION
This is required fix for the monorepos. Future version of confluenza will make this fix not necessary.