### PR TITLE
Distribute ios app

### DIFF
--- a/workspaces/cogito-ios-app-distribution/.env
+++ b/workspaces/cogito-ios-app-distribution/.env
@@ -1,2 +1,3 @@
 BROWSER="google chrome"
 NODE_PATH=src/
+SKIP_PREFLIGHT_CHECK=true

--- a/workspaces/cogito-ios-app-distribution/Dockerfile
+++ b/workspaces/cogito-ios-app-distribution/Dockerfile
@@ -1,0 +1,19 @@
+FROM  node:10.11.0 as base
+LABEL description="Cogito IOS distribution"
+
+WORKDIR /apps/cogito-ios-app-distribution
+
+COPY . .
+RUN yarn install
+RUN yarn build --production
+
+FROM nginx:alpine
+ENV HTPASSWD='philips:$apr1$edu3G9YE$zFZDqLyMIVa.pmaqJNSJX/'
+
+WORKDIR /apps/cogito-ios-app-distribution
+RUN apk add --no-cache gettext
+
+COPY auth.conf auth.htpasswd launch.sh ./
+
+COPY --from=base /apps/cogito-ios-app-distribution/build/ build
+CMD ["./launch.sh"]

--- a/workspaces/cogito-ios-app-distribution/auth.conf
+++ b/workspaces/cogito-ios-app-distribution/auth.conf
@@ -1,0 +1,12 @@
+server {
+ listen 80 default_server;
+
+ location / {
+     auth_basic              "Restricted";
+     auth_basic_user_file    auth.htpasswd;
+
+     proxy_read_timeout                  900;
+     root /apps/cogito-ios-app-distribution/build;
+     index index.html;
+ }
+}

--- a/workspaces/cogito-ios-app-distribution/auth.htpasswd
+++ b/workspaces/cogito-ios-app-distribution/auth.htpasswd
@@ -1,0 +1,1 @@
+${HTPASSWD}

--- a/workspaces/cogito-ios-app-distribution/launch.sh
+++ b/workspaces/cogito-ios-app-distribution/launch.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rm /etc/nginx/conf.d/default.conf || :
+envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
+envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
+
+nginx -g "daemon off;"

--- a/workspaces/cogito-ios-app-distribution/now.json
+++ b/workspaces/cogito-ios-app-distribution/now.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "cloud": "v1"
+  },
+  "name": "app-cogito-mobi",
+  "type": "docker",
+  "alias": "app",
+  "scale": {
+    "bru1": {
+      "min": 1,
+      "max": 1
+    }
+  }
+}

--- a/workspaces/cogito-ios-app-distribution/package.json
+++ b/workspaces/cogito-ios-app-distribution/package.json
@@ -15,7 +15,6 @@
     "semantic-ui-react": "^0.79.1"
   },
   "devDependencies": {
-    "@cogitojs/faucet": "^0.2.17",
     "deep-freeze-es6": "^1.0.1",
     "jest-canvas-mock": "^1.0.2",
     "react-scripts": "^2.0.0",
@@ -26,6 +25,7 @@
     "build": "react-scripts build",
     "test": "yarn lint && react-scripts test --env=jsdom",
     "lint": "yarn standard",
+    "deploy": "(cp ../../yarn.lock .) && ((now -e HTPASSWD=$HTPASSWD--public && rm yarn.lock) || rm yarn.lock)",
     "lint-fix": "yarn standard --fix --verbose"
   },
   "jest": {

--- a/workspaces/cogito-ios-app-distribution/public/index.html
+++ b/workspaces/cogito-ios-app-distribution/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Cogito iOS app</title>
   </head>
   <body>
     <noscript>

--- a/workspaces/cogito-ios-app-distribution/src/index.js
+++ b/workspaces/cogito-ios-app-distribution/src/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'


### PR DESCRIPTION
I've set up the distibution of the iOS app.

I haven't configured the now settings, because I'm not sure about the url of the application. This url is also used in the application (`src/components/imageAppLink/ImageAppLink.js`). @marcinczenko can you look at this?

Before doing `yarn deploy` you should copy the `ipa` and `manifests.plist` to the `public` folder.

I will add instructions on how to make the necessary files for the actual application.