### PR TITLE
Reverts "Adds missing gitignores"

### DIFF
--- a/workspaces/cogito-react/.gitignore
+++ b/workspaces/cogito-react/.gitignore
@@ -1,4 +1,0 @@
-es
-node_modules
-umd
-lib

--- a/workspaces/cogito-web3/.gitignore
+++ b/workspaces/cogito-web3/.gitignore
@@ -1,4 +1,0 @@
-es
-node_modules
-umd
-lib

--- a/workspaces/cogito/.gitignore
+++ b/workspaces/cogito/.gitignore
@@ -1,4 +1,0 @@
-es
-node_modules
-umd
-lib


### PR DESCRIPTION
This reverts commit e74479c09d211d806a380a056d8f1cbc2750ed10. My bad: my workspace was not clean so I didn't notice that these folders had in fact been removed entirely.