### PR TITLE
Bug display larger qr code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,18 @@
 module.exports = {
   projects: [
-    'workspaces/cogito-web3-provider',
-    'workspaces/cogito-ethereum',
-    'workspaces/cogito-ethereum-react',
-    'workspaces/cogito-encryption',
-    'workspaces/cogito-identity',
     'workspaces/cogito-attestations',
-    'workspaces/telepath-js',
-    'workspaces/telepath-queuing-service',
-    'workspaces/demo-app',
+    'workspaces/cogito-encryption',
+    'workspaces/cogito-ethereum-react',
+    'workspaces/cogito-ethereum',
+    'workspaces/cogito-identity',
+    'workspaces/cogito-ios-app-distribution',
+    'workspaces/cogito-react-ui',
+    'workspaces/cogito-web3-provider',
     'workspaces/crypto',
+    'workspaces/demo-app',
     'workspaces/faucet',
-    'workspaces/cogito-ios-app-distribution'
+    'workspaces/telepath-js',
+    'workspaces/telepath-queuing-service'
   ],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import QRCode from 'qrcode.react'
 
-const CogitoQRCode = ({ url, title = 'Cogito QR Code' }) => (
-  <a href={url} title={title}>
-    <QRCode value={url} />
+const CogitoQRCode = ({ connectUrl, title = 'Cogito QR Code' }) => (
+  <a href={connectUrl} title={title}>
+    <QRCode value={connectUrl} />
   </a>
 )
 

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.js
@@ -1,33 +1,10 @@
 import React from 'react'
 import QRCode from 'qrcode.react'
 
-class CogitoQRCode extends React.Component {
-  state = {}
-
-  componentDidMount () {
-    const canvas = document.querySelector('canvas')
-    if (canvas) {
-      this.setState({
-        canvas: {
-          url: canvas.toDataURL(),
-          width: canvas.width / 2,
-          height: canvas.height / 2
-        }
-      })
-    }
-  }
-
-  render () {
-    const { canvas } = this.state
-    return (
-      <a href={this.props.value} title={this.props.title}>
-        { !canvas && <QRCode
-          value={this.props.value}
-        /> }
-        { canvas && <img alt='qr-code' src={canvas.url} width={canvas.width} height={canvas.height} /> }
-      </a>
-    )
-  }
-}
+const CogitoQRCode = ({ url, title = 'Cogito QR Code' }) => (
+  <a href={url} title={title}>
+    <QRCode value={url} />
+  </a>
+)
 
 export { CogitoQRCode }

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.js
@@ -20,12 +20,12 @@ class CogitoQRCode extends React.Component {
   render () {
     const { canvas } = this.state
     return (
-      <div>
+      <a href={this.props.value} title={this.props.title}>
         { !canvas && <QRCode
           value={this.props.value}
         /> }
         { canvas && <img alt='qr-code' src={canvas.url} width={canvas.width} height={canvas.height} /> }
-      </div>
+      </a>
     )
   }
 }

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
@@ -4,17 +4,17 @@ import { CogitoQRCode } from './CogitoQRCode'
 
 describe('CogitoQRCode', () => {
   const title = 'Link in QR Code'
-  const url = 'https://url-in-qr.code/'
+  const connectUrl = 'https://url-in-qr.code/'
 
   it('shows QR code', () => {
-    const { queryByText } = render(<CogitoQRCode url={url} />)
+    const { queryByText } = render(<CogitoQRCode connectUrl={connectUrl} />)
 
-    expect(queryByText(url)).not.toBeNull()
+    expect(queryByText(connectUrl)).not.toBeNull()
   })
 
   it('links to the URL', () => {
-    const { getByTitle } = render(<CogitoQRCode title={title} url={url} />)
+    const { getByTitle } = render(<CogitoQRCode title={title} connectUrl={connectUrl} />)
 
-    expect(getByTitle(title).href).toEqual(url)
+    expect(getByTitle(title).href).toEqual(connectUrl)
   })
 })

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
@@ -9,4 +9,12 @@ describe('CogitoQRCode', () => {
 
     expect(queryByText(value)).not.toBeNull()
   })
+
+  it('links to the URL', () => {
+    const title = 'Link in QR Code'
+    const url = 'https://url-in-qr.code/'
+    const { getByTitle } = render(<CogitoQRCode title={title} value={url} />)
+
+    expect(getByTitle(title).href).toEqual(url)
+  })
 })

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
@@ -3,17 +3,17 @@ import { render } from 'react-testing-library'
 import { CogitoQRCode } from './CogitoQRCode'
 
 describe('CogitoQRCode', () => {
-  it('shows QR code', () => {
-    const value = 'https://url-in-qr.code'
-    const { queryByText } = render(<CogitoQRCode value={value} />)
+  const title = 'Link in QR Code'
+  const url = 'https://url-in-qr.code/'
 
-    expect(queryByText(value)).not.toBeNull()
+  it('shows QR code', () => {
+    const { queryByText } = render(<CogitoQRCode url={url} />)
+
+    expect(queryByText(url)).not.toBeNull()
   })
 
   it('links to the URL', () => {
-    const title = 'Link in QR Code'
-    const url = 'https://url-in-qr.code/'
-    const { getByTitle } = render(<CogitoQRCode title={title} value={url} />)
+    const { getByTitle } = render(<CogitoQRCode title={title} url={url} />)
 
     expect(getByTitle(title).href).toEqual(url)
   })

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from 'react-testing-library'
+import { CogitoQRCode } from './CogitoQRCode'
+
+describe('CogitoQRCode', () => {
+  it('shows QR code', () => {
+    const value = 'https://url-in-qr.code'
+    const { queryByText } = render(<CogitoQRCode value={value} />)
+
+    expect(queryByText(value)).not.toBeNull()
+  })
+})

--- a/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
+++ b/workspaces/cogito-react-ui/source/CogitoQRCode.test.js
@@ -3,13 +3,15 @@ import { render } from 'react-testing-library'
 import { CogitoQRCode } from './CogitoQRCode'
 
 describe('CogitoQRCode', () => {
+  const defaultTitle = 'Cogito QR Code'
   const title = 'Link in QR Code'
   const connectUrl = 'https://url-in-qr.code/'
 
-  it('shows QR code', () => {
-    const { queryByText } = render(<CogitoQRCode connectUrl={connectUrl} />)
+  it('shows QR code with default title', () => {
+    const { queryByText, queryByTitle } = render(<CogitoQRCode connectUrl={connectUrl} />)
 
     expect(queryByText(connectUrl)).not.toBeNull()
+    expect(queryByTitle(defaultTitle).href).not.toBeNull()
   })
 
   it('links to the URL', () => {

--- a/workspaces/cogito-react-ui/source/__mocks__/qrcode.react.js
+++ b/workspaces/cogito-react-ui/source/__mocks__/qrcode.react.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const MockedQRCode = ({ value }) => <div>{ value }</div>
+
+export default MockedQRCode

--- a/workspaces/cogito-react-ui/source/cogito-connector/ConnectorBody.js
+++ b/workspaces/cogito-react-ui/source/cogito-connector/ConnectorBody.js
@@ -9,7 +9,7 @@ const ConnectorBody = ({ connectUrl, buttonStyling, onDone }) => (
     <Spacer
       margin='20px 0 50px 0'
       render={() =>
-        <CogitoQRCode key={connectUrl} value={connectUrl} />
+        <CogitoQRCode key={connectUrl} url={connectUrl} />
       } />
     <Button {...buttonStyling} onClick={onDone}>Done</Button>
   </Centered>

--- a/workspaces/cogito-react-ui/source/cogito-connector/ConnectorBody.js
+++ b/workspaces/cogito-react-ui/source/cogito-connector/ConnectorBody.js
@@ -9,7 +9,7 @@ const ConnectorBody = ({ connectUrl, buttonStyling, onDone }) => (
     <Spacer
       margin='20px 0 50px 0'
       render={() =>
-        <CogitoQRCode key={connectUrl} url={connectUrl} />
+        <CogitoQRCode key={connectUrl} connectUrl={connectUrl} />
       } />
     <Button {...buttonStyling} onClick={onDone}>Done</Button>
   </Centered>

--- a/workspaces/demo-app/src/components/cogito-attestations/CogitoAttestations.js
+++ b/workspaces/demo-app/src/components/cogito-attestations/CogitoAttestations.js
@@ -22,7 +22,7 @@ const ShowAttestation = () => (
   <Centered css={{ padding: '10px', marginRight: '50px', backgroundColor: 'white' }}>
     <p>Scan to add a dummy attestation:</p>
     <CogitoQRCode
-      value='https://cogito.mobi/attestations/receive#A=email%3Atest.user%40philips.com'
+      url='https://cogito.mobi/attestations/receive#A=email%3Atest.user%40philips.com'
     />
   </Centered>
 )

--- a/workspaces/demo-app/src/components/cogito-attestations/CogitoAttestations.js
+++ b/workspaces/demo-app/src/components/cogito-attestations/CogitoAttestations.js
@@ -22,7 +22,7 @@ const ShowAttestation = () => (
   <Centered css={{ padding: '10px', marginRight: '50px', backgroundColor: 'white' }}>
     <p>Scan to add a dummy attestation:</p>
     <CogitoQRCode
-      url='https://cogito.mobi/attestations/receive#A=email%3Atest.user%40philips.com'
+      connectUrl='https://cogito.mobi/attestations/receive#A=email%3Atest.user%40philips.com'
     />
   </Centered>
 )


### PR DESCRIPTION
Issue: #81 

The QR code was rendered with the height and width divided by 2. Simplified the rendering and wrap the React QRCode element with an Anchor (link) element.

TODO:
- [x] Check demo-app in mobile device to make sure the link works
- [x] Check QR code rendering in demo-app
- [x] Check on monitor with low resolution settings