### PR TITLE
For Travis only build master branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
     - BUNDLE_GEMFILE=.ruby-dependencies/Gemfile
     # Code coverage key
     - secure: QiKA+JoGk6C7PFdphqS6k9hC6p1TO7cBBhoF3NMlGo2mlwxoVnagtUpoM5kmUW2PoG49LMGxQI/oerQMSqY/dJa0df9UlffMZTs6UIBdxbbeg7Rp/gh0DMMQQGG2mokBLM8Ivm/tFxlf8Y8CHHSWgBWjKTvnlX21nTvYgqqiCfcEmae/kJgBq9M/w9cQNXFnQJm6FsTrekESBlX4CzmyWxeLWVGEvgsXTwg6FsNVIZFuiSJPflLja5X7MzizZX73jvKRHCts49/ftO1TL6ii5DjuYBOzILg9Zlo01Y+2AgTYAX8dou+wUDbHfPsK66trB4wblDmqyB9dcWG+2oc8cMEGqyrIAFP5wEvuVqkujPHBBc7gYJNXBCFDS/Qy/Xmobj4YbSPnw9gnYK+Ba5nM89/zJOQUnozWcitlfkFnho+PMEYrciYnTOJsnT2MV/GGc1B7ccT8HrAkU8jQQgwh+i56TgzXR7KJ0g40eEKK98RLcSjrVOy35NInrnSy7WawpydseLOxRtjLZPnKLrAOtMJ2zbjx8xnAldzLxK9lwsEQGBBAcieDoJheEwUVIOEHW7gyIGOMBoqY8zLWdcpKgy/luOxLdXtI4IxvqMtHOtvkC1BbH6mAbfeBmmCAcHfDlZ9ldnR647kKr+TPvyKMHqvZX16E+UAOVEnJ9QNEiRc=
+# Only build the master branch, not feature branches. It will still build PRs
+branches:
+  only:
+  - master
 before_install:
   # Use bundler 2.0
   - gem update --system


### PR DESCRIPTION
 Pull Requests now have double builds, on the branch and on the PR itself. There is a switch in Travis to stop building branches, but we don't want that, because it would also stop building the `master` branch.

It is possible to tweak the `.travis.yml` to only build the `master` branch. This setting will still build all PRs.