### PR TITLE
Fix deployment with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ after_success:
   # Upload test coverage to Code Climate
   - ./cc-test-reporter upload-coverage
 deploy:
+  skip_cleanup: true
   provider: script
   script: yarn deploy
   on:


### PR DESCRIPTION
Ensure that the built artifacts are not cleaned by Travis before
deploying. They include node_modules, which is necessary to run Lerna,
for instance.