### PR TITLE
Storage balance

### DIFF
--- a/workspaces/demo-app/src/components/cogito-contract/CogitoContract.test.js
+++ b/workspaces/demo-app/src/components/cogito-contract/CogitoContract.test.js
@@ -225,6 +225,7 @@ describe('CogitoContract', () => {
       )
       const showQRCodeButton = getByText(/show qr code/i)
       fireEvent.click(showQRCodeButton)
+      await waitForElement(() => getByText(/scan the qr code/i))
       fakeConnectionSetupDone()
       fireEvent.click(increaseButton)
       await wait(() =>

--- a/workspaces/demo-app/src/components/cogito-contract/SimpleStorageBalance.js
+++ b/workspaces/demo-app/src/components/cogito-contract/SimpleStorageBalance.js
@@ -8,13 +8,26 @@ import { UserDataActions } from 'user-data'
 class SimpleStorageBalance extends Component {
   valueWatcher
 
-  componentDidMount () {
+  watchSimpleStorageEvents = () => {
     const { simpleStorage, dispatch } = this.props
     this.valueWatcher = new ValueWatcher({
       simpleStorage,
       onValueChanged: value => dispatch(UserDataActions.setBalance(value))
     })
     this.valueWatcher.start()
+  }
+
+  componentDidMount () {
+    this.watchSimpleStorageEvents()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (this.props.simpleStorage !== prevProps.simpleStorage) {
+      if (this.valueWatcher) {
+        this.valueWatcher.stop()
+        this.watchSimpleStorageEvents()
+      }
+    }
   }
 
   componentWillUnmount () {

--- a/workspaces/demo-app/src/components/cogito-contract/SimpleStorageBalance.test.js
+++ b/workspaces/demo-app/src/components/cogito-contract/SimpleStorageBalance.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SimpleStorageMock } from 'test-helpers'
-import { render, wait } from 'test-helpers/render-props'
+import { render, rerender, wait } from 'test-helpers/render-props'
 import { createStore } from 'redux'
 import { rootReducer } from 'app-state/rootReducer'
 
@@ -23,6 +23,19 @@ describe('SimpleStorageBalance', () => {
     expect(getByTestId(/current-value/i)).toHaveTextContent('0')
     simpleStorage.simulateValueChange(value)
     expect(getByTestId(/current-value/i)).toHaveTextContent(`${value}`)
+  })
+
+  it('restarts watching when contract instance changes', async () => {
+    const { getByTestId, rerender: rerenderRtl } = render(<SimpleStorageBalance dispatch={store.dispatch} simpleStorage={simpleStorage} />, { store })
+    expect(getByTestId(/current-value/i)).toHaveTextContent('0')
+    simpleStorage.simulateValueChange(value)
+    expect(getByTestId(/current-value/i)).toHaveTextContent(`${value}`)
+
+    simpleStorage = new SimpleStorageMock()
+    rerender(rerenderRtl, <SimpleStorageBalance dispatch={store.dispatch} simpleStorage={simpleStorage} />, store)
+    expect(getByTestId(/current-value/i)).toHaveTextContent(`${value}`)
+    simpleStorage.simulateValueChange(value + 10)
+    expect(getByTestId(/current-value/i)).toHaveTextContent(`${value + 10}`)
   })
 
   it('stops watching value changes after component is unmounted', async () => {

--- a/workspaces/demo-app/src/components/cogito-contract/SimpleStorageControls.js
+++ b/workspaces/demo-app/src/components/cogito-contract/SimpleStorageControls.js
@@ -26,8 +26,9 @@ class SimpleStorageControls extends Component {
     )
   }
 
-  onOpen = dispatch => {
-    this.props.newChannel()
+  onOpen = async dispatch => {
+    const { newChannel } = this.props
+    await newChannel()
     this.setState({ forceFetchingIdentity: true })
     dispatch(AppEventsActions.setDialogOpen())
   }


### PR DESCRIPTION
This pull-request fixes two problems:

1) When clicking "Show QR Code" button we need to do the same as we do in the Cogito Identity demo  - wait for the `newChannel` function to return. Otherwise, the dialog that pops up will show invalid QR Code for a short moment.

2) When clicking "Show QR Code" a new telepath channel is created and so also a new instance of the SimpleStorage contract. This has to be observed in `SimpleStorageBalance` and restart the event watcher when change occurs. Without this, we will be observing events on the disconnected instance of the contract which will reveal itself by producing a whole range of connection errors "connection not open on send". After fixing this, there will still be a glitch, but the connection will be properly restored almost immediately.
