### PR TITLE
Git Hook for Cogito Mobile commit messages

### DIFF
--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -3,7 +3,7 @@
 # Symlink this precommit hook to your `.git/hooks` directory
 # From root directory (where .git is in)
 BRANCH=$(git symbolic-ref --short HEAD)
-WORKSPACE_COMMIT_MSG="\[cogito-mobile\] "
+WORKSPACE_COMMIT_MSG="\[📱\] "
 
 if [[ $BRANCH =~ ^(cogito-mobile|cm|mob|mobile) ]] ; then
   sed -i.bak -e "1s/^/$WORKSPACE_COMMIT_MSG/" "$1"

--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -3,7 +3,7 @@
 # Symlink this precommit hook to your `.git/hooks` directory
 # From root directory (where .git is in)
 BRANCH=$(git symbolic-ref --short HEAD)
-WORKSPACE_COMMIT_MSG="\[📱\] "
+WORKSPACE_COMMIT_MSG="📱 "
 
 if [[ $BRANCH =~ ^(cogito-mobile|cm|mob|mobile) ]] ; then
   sed -i.bak -e "1s/^/$WORKSPACE_COMMIT_MSG/" "$1"

--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 # Symlink this precommit hook to your `.git/hooks` directory
 # From root directory (where .git is in)
 BRANCH=$(git symbolic-ref --short HEAD)
 WORKSPACE_COMMIT_MSG="\[cogito-mobile\] "
 
-if [[ $BRANCH =~ ^(cogito-mobile|cm|mob) ]] ; then
+if [[ $BRANCH =~ ^(cogito-mobile|cm|mob|mobile) ]] ; then
   sed -i.bak -e "1s/^/$WORKSPACE_COMMIT_MSG/" "$1"
   echo $gg;
 fi

--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Symlink this precommit hook to your `.git/hooks` directory
+# From root directory (where .git is in)
+BRANCH=$(git symbolic-ref --short HEAD)
+WORKSPACE_COMMIT_MSG="\[cogito-mobile\] "
+
+if [[ $BRANCH =~ ^(cogito-mobile|cm|mob) ]] ; then
+  sed -i.bak -e "1s/^/$WORKSPACE_COMMIT_MSG/" "$1"
+  echo $gg;
+fi


### PR DESCRIPTION
I've scratched my own itch by making a git hook to prepends a commit message with `[cogito-mobile]` whenever there is a branch that starts with `cogito-mobile`, `cm`, or `mob`.

I simply got tired of typing `[cogito-mobile]` all the time.

Feel free to contribute and to use for other workspaces and projects as well