### PR TITLE
Fix deployment

### DIFF
--- a/workspaces/telepath-queuing-service/package.json
+++ b/workspaces/telepath-queuing-service/package.json
@@ -6,8 +6,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "ncc run index.js",
-    "deploy": "now --scope software-concepts --token $NOW_TOKEN && now alias --scope software-concepts --token $NOW_TOKEN"
+    "start": "ncc run index.js"
   },
   "engines": {
     "node": ">=7.6.0"


### PR DESCRIPTION
Remove deployment script of telepath queuing service. Zeit 1.0 services are no longer supported, and there is no straightforward path to upgrading to lambda's